### PR TITLE
Merge space screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,6 +17,7 @@ import {
 // import AppSpaceList from "./components/AppSpaceList.js";
 // import SpaceDetailScreen from "./screens/SpaceDetailScreen.js";
 import Screen from "./components/Screen.js";
+
 // import ListItemSeparator from "./components/ListItemSeparator.js";
 
 // const Tweets = ({ navigation }) => (
@@ -46,18 +47,21 @@ import Screen from "./components/Screen.js";
 //   appId: "1:996802332043:web:1713c7aec7d3ec23071b8e",
 // };
 
-var firebaseConfig = {
-  apiKey: "AIzaSyAz7kUCB102_eT2R0F7diW47wczPlqCtck",
-  authDomain: "musalla-ea1ab.firebaseapp.com",
-  databaseURL: "https://musalla-ea1ab.firebaseio.com",
-  projectId: "musalla-ea1ab",
-  storageBucket: "musalla-ea1ab.appspot.com",
-  messagingSenderId: "239388429818",
-  appId: "1:239388429818:web:584e11323fa99fbf7b6843",
-  measurementId: "G-NP7RNBY59B",
-};
-firebase.initializeApp(firebaseConfig);
+// var firebaseConfig = {
+//   apiKey: "AIzaSyAz7kUCB102_eT2R0F7diW47wczPlqCtck",
+//   authDomain: "musalla-ea1ab.firebaseapp.com",
+//   databaseURL: "https://musalla-ea1ab.firebaseio.com",
+//   projectId: "musalla-ea1ab",
+//   storageBucket: "musalla-ea1ab.appspot.com",
+//   messagingSenderId: "239388429818",
+//   appId: "1:239388429818:web:584e11323fa99fbf7b6843",
+//   measurementId: "G-NP7RNBY59B",
+// };
+// firebase.initializeApp(firebaseConfig);
 // firebase.analytics();
+
+import ViewSpacesScreen from "./screens/ViewSpacesScreen";
+import ListViewScreen from "./screens/ListViewScreen";
 
 export default function App() {
   const sampleSpace = {
@@ -74,9 +78,11 @@ export default function App() {
     // <Screen style={{ flex: 1, padding: 20 }}>
     //   <AppSpaceList />
     // </Screen>
-    <NavigationContainer>
-      <ScreenNavigator />
-    </NavigationContainer>
+    // <NavigationContainer>
+    //   <ScreenNavigator />
+    // </NavigationContainer>
+    <ViewSpacesScreen />
+    // <ListViewScreen />
   );
   // return <SpaceDetailScreen space={sampleSpace} />;
 }

--- a/App.tsx
+++ b/App.tsx
@@ -60,6 +60,7 @@ import Screen from "./components/Screen.js";
 // firebase.initializeApp(firebaseConfig);
 // firebase.analytics();
 
+import MapViewScreen from "./screens/MapViewScreen";
 import ViewSpacesScreen from "./screens/ViewSpacesScreen";
 import ListViewScreen from "./screens/ListViewScreen";
 
@@ -82,6 +83,7 @@ export default function App() {
     //   <ScreenNavigator />
     // </NavigationContainer>
     <ViewSpacesScreen />
+    // <MapViewScreen />
     // <ListViewScreen />
   );
   // return <SpaceDetailScreen space={sampleSpace} />;

--- a/components/AppMapView.js
+++ b/components/AppMapView.js
@@ -1,0 +1,114 @@
+import React from "react";
+import { Dimensions, StyleSheet, Text, View } from "react-native";
+import MapView, { Marker, Callout, CalloutSubview } from "react-native-maps";
+
+// import { closedSpacesList, openSpacesList } from "../config/dummySpaces";
+// import { mapMarkersClosed, mapMarkersOpen } from "../functions/MapMarkers";
+
+var arr1 = [
+  {
+    building_address_city: "Philadelphia",
+    building_address_street: "3417 Spruce Street",
+    building_address_zip: "19104",
+    building_name: "Houston Hall",
+    bldgName: "Houston Hall",
+    bldgAddress: "3417 Spruce Street, Philadelphia, PA 19104",
+    latitude: "39.95052",
+    longitude: "-75.192920",
+    capacity: "2",
+    dailyHours: "2PM - 5PM",
+    instructions:
+      "Inside Houston Hall, go up to the second floor and you will see SPARC.",
+    spaceName: "SPARC",
+  },
+];
+var arr2 = [
+  {
+    Carpet: true,
+    Notes: "Anything",
+    accessibility: "Penn Ok",
+    building_address: {
+      city: "Philadelphia",
+      state: "Pennsylvania",
+      street: "3800 Walnut Street",
+    },
+    bldgAddress: "3800 Walnut Street, Philadelphia, PA 19104",
+    building_address_city: "Philadelphia",
+    building_address_street: "3800 Walnut Street",
+    building_address_zip: "19104",
+    building_name: "Huntsman Hall",
+    bldgName: "Huntsman Hall",
+    capacity: "10",
+    cleanliness: 3,
+    instructions: "Go up Walnut. It is the great red building.",
+    latitude: "39.95289",
+    longitude: "-75.1982",
+    nearby_wudhu: "around the corner - the washrooms",
+    passers_by: "none",
+    space_name: "huntsman",
+    dailyHours: "10AM - 10PM",
+    spaceName: "Huntsman",
+  },
+];
+
+function AppMapView(props) {
+  let mapMarkersClosed = () => {
+    return arr2.map((report) => (
+      <Marker
+        key={report.building_name}
+        coordinate={{
+          latitude: Number(report.latitude),
+          longitude: Number(report.longitude),
+        }}
+        pinColor={"green"}
+        title={report.building_name}
+        description={"Open"}
+        // onCalloutPress={this.state.navigation.navigate("SpaceDetail", {
+        // values: arr2[0],
+        // })}
+        // onPress={console.log("WHAT's GOOD")}
+      >
+        <Callout tooltip>
+          <CalloutSubview
+            onPress={() =>
+              this.state.navigation.navigate("SpaceDetail", {
+                values: arr2[0],
+                source: "map",
+              })
+            }
+          >
+            <View>
+              <View style={styles.callout}>
+                <Text>{report.building_name}</Text>
+              </View>
+            </View>
+          </CalloutSubview>
+        </Callout>
+      </Marker>
+    ));
+  };
+
+  return (
+    <MapView
+      style={styles.mapStyle}
+      region={{
+        latitude: 39.95523,
+        longitude: -75.19464,
+        latitudeDelta: 0.00922,
+        longitudeDelta: 0.00421,
+      }}
+      showsUserLocation={true}
+    >
+      {mapMarkersClosed(arr1)}
+    </MapView>
+  );
+}
+
+const styles = StyleSheet.create({
+  mapStyle: {
+    width: Dimensions.get("window").width,
+    height: "100%",
+  },
+});
+
+export default AppMapView;

--- a/components/AppMapView.js
+++ b/components/AppMapView.js
@@ -2,58 +2,32 @@ import React from "react";
 import { Dimensions, StyleSheet, Text, View } from "react-native";
 import MapView, { Marker, Callout, CalloutSubview } from "react-native-maps";
 
-// import { closedSpacesList, openSpacesList } from "../config/dummySpaces";
+// import * from "../constants/dummySpaces";
 // import { mapMarkersClosed, mapMarkersOpen } from "../functions/MapMarkers";
 
-var arr1 = [
-  {
-    building_address_city: "Philadelphia",
-    building_address_street: "3417 Spruce Street",
-    building_address_zip: "19104",
-    building_name: "Houston Hall",
-    bldgName: "Houston Hall",
-    bldgAddress: "3417 Spruce Street, Philadelphia, PA 19104",
-    latitude: "39.95052",
-    longitude: "-75.192920",
-    capacity: "2",
-    dailyHours: "2PM - 5PM",
-    instructions:
-      "Inside Houston Hall, go up to the second floor and you will see SPARC.",
-    spaceName: "SPARC",
-  },
-];
-var arr2 = [
-  {
-    Carpet: true,
-    Notes: "Anything",
-    accessibility: "Penn Ok",
-    building_address: {
-      city: "Philadelphia",
-      state: "Pennsylvania",
-      street: "3800 Walnut Street",
-    },
-    bldgAddress: "3800 Walnut Street, Philadelphia, PA 19104",
-    building_address_city: "Philadelphia",
-    building_address_street: "3800 Walnut Street",
-    building_address_zip: "19104",
-    building_name: "Huntsman Hall",
-    bldgName: "Huntsman Hall",
-    capacity: "10",
-    cleanliness: 3,
-    instructions: "Go up Walnut. It is the great red building.",
-    latitude: "39.95289",
-    longitude: "-75.1982",
-    nearby_wudhu: "around the corner - the washrooms",
-    passers_by: "none",
-    space_name: "huntsman",
-    dailyHours: "10AM - 10PM",
-    spaceName: "Huntsman",
-  },
-];
-
 function AppMapView(props) {
-  let mapMarkersClosed = () => {
-    return arr2.map((report) => (
+  // TODO Can't figure out how to define this dummy data in a separate
+  //  file and import, unfortunately
+  let closedSpacesList = [
+    {
+      building_address_city: "Philadelphia",
+      building_address_street: "3417 Spruce Street",
+      building_address_zip: "19104",
+      building_name: "Houston Hall",
+      bldgName: "Houston Hall",
+      bldgAddress: "3417 Spruce Street, Philadelphia, PA 19104",
+      latitude: "39.95052",
+      longitude: "-75.192920",
+      capacity: "2",
+      dailyHours: "2PM - 5PM",
+      instructions:
+        "Inside Houston Hall, go up to the second floor and you will see SPARC.",
+      spaceName: "SPARC",
+    },
+  ];
+
+  function mapMarkersClosed(spaceList) {
+    return spaceList.map((report) => (
       <Marker
         key={report.building_name}
         coordinate={{
@@ -72,6 +46,7 @@ function AppMapView(props) {
           <CalloutSubview
             onPress={() =>
               this.state.navigation.navigate("SpaceDetail", {
+                // TODO: fix this "arr2" here?
                 values: arr2[0],
                 source: "map",
               })
@@ -86,7 +61,7 @@ function AppMapView(props) {
         </Callout>
       </Marker>
     ));
-  };
+  }
 
   return (
     <MapView
@@ -99,7 +74,7 @@ function AppMapView(props) {
       }}
       showsUserLocation={true}
     >
-      {mapMarkersClosed(arr1)}
+      {mapMarkersClosed(closedSpacesList)}
     </MapView>
   );
 }

--- a/screens/ViewSpacesScreen.js
+++ b/screens/ViewSpacesScreen.js
@@ -1,11 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import AppButton from "../components/AppButton";
 import AppSpaceList from "../components/AppSpaceList";
 import AppTitle from "../components/AppTitle.js";
 import AppText from "../components/AppText";
+import MapViewScreen from "./MapViewScreen";
 import Screen from "../components/Screen";
+
+import AppMapView from "../components/AppMapView";
 
 /**
  * This component specifies appearance of the screen that shows both list of
@@ -14,21 +17,49 @@ import Screen from "../components/Screen";
  */
 
 function ViewSpacesScreen(props) {
+  const [mapVisible, setMapVisible] = useState(false);
+
   return (
     <Screen style={{ flex: 1, padding: 20 }}>
-      <View style={styles.container}>
-        <AppText customStyle={styles.title}>hey there</AppText>
+      <View style={styles.headingContainer}>
+        <AppText customStyle={styles.title}>View Spaces</AppText>
       </View>
+
+      <View style={styles.container}>
+        {/* Render map or list of spaces, based on mapVisible */}
+        {mapVisible ? (
+          <AppMapView />
+        ) : (
+          <View style={styles.spaceListContainer}>
+            <AppSpaceList />
+          </View>
+        )}
+      </View>
+      <AppButton
+        title={mapVisible ? "List View" : "Map View"}
+        onPress={() => setMapVisible(!mapVisible)}
+      />
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     marginTop: 20,
     marginBottom: 40,
+    borderColor: "blue",
+    borderWidth: 2,
+  },
+  headingContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  spaceListContainer: {
+    flex: 1,
+    width: "90%",
   },
   title: {
     fontSize: 30,


### PR DESCRIPTION
This commit does a few things:

* Creates a `AppMapView` component - pulls the map into a component, instead of a screen, so that list/map view can be on the same screen
* Creates a `ViewSpacesScreen` : a single screen that presents both the list of spaces and the map and allows toggling between them at the click of a button

Things that still need to be done:
* Integrating this new setup (combined map/list view) with navigation between screens
* Potentially: map view on each individual space's Details screen?